### PR TITLE
Added `MonadError` instance.

### DIFF
--- a/either.cabal
+++ b/either.cabal
@@ -30,7 +30,8 @@ library
     base          >= 4       && < 5,
     semigroups    >= 0.8.3.1,
     semigroupoids >= 3,
-    transformers  >= 0.2     && < 0.4
+    transformers  >= 0.2     && < 0.4,
+    mtl           >= 2
 
   extensions: CPP
 


### PR DESCRIPTION
> This requires a dependency on _mtl_.
> Defined `left`, `right` and `hoistEither` in terms of `MonadError`.

Inspired by [this SO question](http://stackoverflow.com/q/14428756/1333025), I realized that `MonadError` is the type class corresponding to `EitherT`. I wonder, why is the instance commented out? Is there a problem with the dependency on _mtl_? With this simple modification, it's possible to use `EitherT` inside a monad stack through `MonadError`.
