### PR TITLE
MonadBase, MonadBaseControl, and MonadTransControl instances for EitherT e

### DIFF
--- a/either.cabal
+++ b/either.cabal
@@ -28,11 +28,13 @@ source-repository head
 library
   build-depends:
     base          >= 4       && < 5,
+    monad-control >= 0.3.2,
     MonadRandom   == 0.1.*,
     mtl           >= 2.0     && < 2.2,
     semigroups    >= 0.8.3.1 && < 1,
     semigroupoids >= 4       && < 5,
-    transformers  >= 0.2     && < 0.4
+    transformers  >= 0.2     && < 0.4,
+    transformers-base >= 0.4
 
   extensions: CPP
   exposed-modules: Control.Monad.Trans.Either,


### PR DESCRIPTION
This introduces dependencies on TypeFamilies, monad-control, and transformers-base.  I'm not sure if this would obviate [johnw's finallyE](https://github.com/ekmett/either/pull/6).
