### PR TITLE
Added `MonadThrow` and `MonadCatch` instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+4.2
+---
+* Added instances for `MonadThrow`, `MonadCatch`.
+
 4.1
 ---
 * Added instances for `MonadBase`, `MonadBaseControl`, and `MonadTransControl`.

--- a/either.cabal
+++ b/either.cabal
@@ -1,6 +1,6 @@
 name:          either
 category:      Control, Monads
-version:       4.1.2
+version:       4.2
 license:       BSD3
 cabal-version: >= 1.6
 license-file:  LICENSE
@@ -34,7 +34,8 @@ library
     semigroups        >= 0.8.3.1 && < 1,
     semigroupoids     >= 4       && < 5,
     transformers      >= 0.2     && < 0.5,
-    transformers-base >= 0.4
+    transformers-base >= 0.4,
+    exceptions        >= 0.5     && < 0.7
 
   extensions: CPP
   exposed-modules: Control.Monad.Trans.Either

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -36,6 +36,7 @@ import Control.Monad (liftM, MonadPlus(..))
 import Control.Monad.Base (MonadBase(..), liftBaseDefault)
 import Control.Monad.Cont.Class
 import Control.Monad.Error.Class
+import Control.Monad.Catch
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
@@ -203,6 +204,16 @@ instance Monad m => MonadError e (EitherT e m) where
     Left  l -> runEitherT (h l)
     Right r -> return (Right r)
   {-# INLINE catchError #-}
+
+-- | Throws exceptions into the base monad.
+instance MonadThrow m => MonadThrow (EitherT e m) where
+  throwM = lift . throwM
+  {-# INLINE throwM #-}
+
+-- | Catches exceptions from the base monad.
+instance MonadCatch m => MonadCatch (EitherT e m) where
+  catch (EitherT m) f = EitherT $ catch m (runEitherT . f)
+  {-# INLINE catch #-}
 
 instance MonadFix m => MonadFix (EitherT e m) where
   mfix f = EitherT $ mfix $ \a -> runEitherT $ f $ case a of


### PR DESCRIPTION
Added `MonadThrow` and `MonadCatch` instances from Exceptions, as discussed in https://github.com/ekmett/either/issues/7.

Cheers
