### PR TITLE
Use Control.Monad.Catch.catch qualified for compatibility with base < 4.6

### DIFF
--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -37,7 +37,7 @@ import Control.Monad.Base (MonadBase(..), liftBaseDefault)
 import Control.Monad.Cont.Class
 import Control.Monad.Error.Class
 import Control.Monad.Free.Class
-import Control.Monad.Catch
+import Control.Monad.Catch as MonadCatch
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
@@ -212,7 +212,7 @@ instance MonadThrow m => MonadThrow (EitherT e m) where
 
 -- | Catches exceptions from the base monad.
 instance MonadCatch m => MonadCatch (EitherT e m) where
-  catch (EitherT m) f = EitherT $ catch m (runEitherT . f)
+  catch (EitherT m) f = EitherT $ MonadCatch.catch m (runEitherT . f)
   {-# INLINE catch #-}
 
 instance MonadFix m => MonadFix (EitherT e m) where


### PR DESCRIPTION
Hi, I just discovered that the new version `either-4.3` can't be installed with a version of `base` older than 4.6 because of a name clash for the function `catch`:

```
[1 of 2] Compiling Data.Either.Combinators ( src/Data/Either/Combinators.hs, dist/build/Data/Either/Combinators.o )
[2 of 2] Compiling Control.Monad.Trans.Either ( src/Control/Monad/Trans/Either.hs, dist/build/Control/Monad/Trans/Either.o )

src/Control/Monad/Trans/Either.hs:215:35:
    Ambiguous occurrence `catch'
    It could refer to either `Prelude.catch',
                             imported from `Prelude' at src/Control/Monad/Trans/Either.hs:24:8-33
                             (and originally defined in `System.IO.Error')
                          or `Control.Monad.Catch.catch',
                             imported from `Control.Monad.Catch' at src/Control/Monad/Trans/Either.hs:40:1-26
```

This affects only GHC 7.4.2 and older, `base-4.6.0.0` and newer have the export of `catch` removed from the `Prelude`.

I fixes this issue by a qualified use of `catch`, maybe you want to merge this change for improved compatibility.
