### PR TITLE
monad-control 0.3.2 compatibility

### DIFF
--- a/either.cabal
+++ b/either.cabal
@@ -31,7 +31,7 @@ library
     bifunctors        >= 4       && < 5,
     exceptions        >= 0.5     && < 0.7,
     free              >= 4.9     && < 5,
-    monad-control     >= 1       && < 1.1,
+    monad-control     >= 0.3.2   && < 1.1,
     MonadRandom       >= 0.1     && < 0.4,
     mtl               >= 2.0     && < 2.3,
     profunctors       >= 4       && < 5,

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -288,15 +288,27 @@ instance MonadBase b m => MonadBase b (EitherT e m) where
   {-# INLINE liftBase #-}
 
 instance MonadTransControl (EitherT e) where
+#if MIN_VERSION_monad_control(1,0,0)
   type StT (EitherT e) a = Either e a
   liftWith f = EitherT $ liftM return $ f runEitherT
+  restoreT   = EitherT
+#else
+  newtype StT (EitherT e) a = StEitherT {unStEitherT :: Either e a}
+  liftWith f = EitherT $ liftM return $ f $ liftM StEitherT . runEitherT
+  restoreT   = EitherT . liftM unStEitherT
+#endif
   {-# INLINE liftWith #-}
-  restoreT = EitherT
   {-# INLINE restoreT #-}
 
 instance MonadBaseControl b m => MonadBaseControl b (EitherT e m) where
+#if MIN_VERSION_monad_control(1,0,0)
   type StM (EitherT e m) a = StM m (StT (EitherT e) a)
   liftBaseWith = defaultLiftBaseWith
-  {-# INLINE liftBaseWith #-}
   restoreM     = defaultRestoreM
+#else
+  newtype StM (EitherT e m) a = StMEitherT { unStMEitherT :: StM m (StT (EitherT e) a) }
+  liftBaseWith = defaultLiftBaseWith StMEitherT
+  restoreM     = defaultRestoreM unStMEitherT
+#endif
+  {-# INLINE liftBaseWith #-}
   {-# INLINE restoreM #-}


### PR DESCRIPTION
Allow old versions of `monad-control` for backwards compatibility.
