### PR TITLE
Add a generic MonadEither class

### DIFF
--- a/either.cabal
+++ b/either.cabal
@@ -42,6 +42,7 @@ library
 
   extensions: CPP
   exposed-modules: Control.Monad.Trans.Either
+                   Control.Monad.Trans.Either.Class
                    Data.Either.Combinators
                    Data.Either.Validation
   ghc-options: -Wall

--- a/src/Control/Monad/Trans/Either/Class.hs
+++ b/src/Control/Monad/Trans/Either/Class.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FlexibleContexts       #-}
+
+module Control.Monad.Trans.Either.Class where
+
+import Control.Monad.Trans (MonadTrans(..))
+import Control.Monad.Trans.Either (EitherT)
+import qualified Control.Monad.Trans.Either as E
+
+class (Monad m) => MonadEither l m | m -> l where
+    hoistEither :: Either l r -> m r
+
+instance (Monad m) => MonadEither l (EitherT l m) where
+    hoistEither = E.hoistEither
+
+instance (MonadTrans t, MonadEither l (t m)) => MonadEither l (EitherT l (t m)) where
+    hoistEither = lift . hoistEither

--- a/src/Control/Monad/Trans/Either/Class.hs
+++ b/src/Control/Monad/Trans/Either/Class.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE OverlappingInstances   #-}
 
 module Control.Monad.Trans.Either.Class where
 
@@ -15,5 +17,5 @@ class (Monad m) => MonadEither l m | m -> l where
 instance (Monad m) => MonadEither l (EitherT l m) where
     hoistEither = E.hoistEither
 
-instance (MonadTrans t, MonadEither l (t m)) => MonadEither l (EitherT l (t m)) where
+instance (MonadEither l m, MonadTrans t, Monad (t m)) => MonadEither l (t m) where
     hoistEither = lift . hoistEither


### PR DESCRIPTION
This class facilitates writing generic code, independent of the actual
Transformer stack.