### PR TITLE
Enhanced documentation of eitherToError. Bump version 4.3.3.3.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,9 +1,13 @@
+4.3.3.3
+-------
+* Fixed and enhanced documentation for `eitherToError`.
+
 4.3.3.2
-------
+-------
 * Support `exceptions` 0.8
 
 4.3.3.1
-------
+-------
 * Support `exceptions` 0.7
 
 4.3.3

--- a/either.cabal
+++ b/either.cabal
@@ -1,6 +1,6 @@
 name:          either
 category:      Control, Monads
-version:       4.3.3.2
+version:       4.3.3.3
 license:       BSD3
 cabal-version: >= 1.6
 license-file:  LICENSE

--- a/src/Data/Either/Combinators.hs
+++ b/src/Data/Either/Combinators.hs
@@ -305,6 +305,9 @@ leftToMaybe = either Just (const Nothing)
 rightToMaybe :: Either a b -> Maybe b
 rightToMaybe = either (const Nothing) Just
 
--- | Generalize 'Either e' as 'MonadError e m'.
+-- | Generalize @Either e@ as @MonadError e m@.
+--
+-- If the argument has form @Left e@, an error is produced in the monad via
+-- 'throwError'. Otherwise, the @Right a@ part is forwarded.
 eitherToError :: (MonadError e m) => Either e a -> m a
 eitherToError = either throwError return


### PR DESCRIPTION
Patch change that fixes haddock format, and add a few lines about the function because it was unclear.