### PR TITLE
Correct the Applicative instances

### DIFF
--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -186,7 +186,7 @@ instance (Applicative m, Monoid e) => Alternative (EitherT e m) where
   empty = EitherT $ pure (Left mempty)
   {-# INLINE empty #-}
 
-instance (Monad m, Monoid e) => MonadPlus (EitherT e m) where
+instance (Applicative m, Monad m, Monoid e) => MonadPlus (EitherT e m) where
   mplus = (<|>)
   {-# INLINE mplus #-}
 
@@ -199,7 +199,7 @@ instance Monad m => Semigroup (EitherT e m a) where
     Right r -> return (Right r)
   {-# INLINE (<>) #-}
 
-instance (Monad m, Semigroup e) => Alt (EitherT e m) where
+instance (Functor m, Monad m, Semigroup e) => Alt (EitherT e m) where
   EitherT m <!> EitherT n = EitherT $ m >>= \a -> case a of
     Left l -> liftM (\b -> case b of
       Left l' -> Left (l <> l')

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -199,12 +199,14 @@ instance Monad m => Semigroup (EitherT e m a) where
     Right r -> return (Right r)
   {-# INLINE (<>) #-}
 
-instance (Functor m, Monad m, Semigroup e) => Alt (EitherT e m) where
-  EitherT m <!> EitherT n = EitherT $ m >>= \a -> case a of
-    Left l -> liftM (\b -> case b of
-      Left l' -> Left (l <> l')
-      Right r -> Right r) n
-    Right r -> return (Right r)
+instance (Apply m, Semigroup e) => Alt (EitherT e m) where
+  (<!>) a b = EitherT $ combine <$> runEitherT a <.> runEitherT b
+    where 
+      combine l r = case l of
+        Left l -> case r of
+          Left l' -> Left ((<>) l l')
+          Right r -> Right r
+        Right r -> Right r
   {-# INLINE (<!>) #-}
 
 instance (Monad m, Apply m) => Bind (EitherT e m) where

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -159,8 +159,8 @@ swapEitherT :: (Functor m) => EitherT e m a -> EitherT a m e
 swapEitherT = EitherT . fmap swapEither . runEitherT
 {-# INLINE swapEitherT #-}
 
-instance Monad m => Functor (EitherT e m) where
-  fmap f = EitherT . liftM (fmap f) . runEitherT
+instance Functor m => Functor (EitherT e m) where
+  fmap f = EitherT . fmap (fmap f) . runEitherT
   {-# INLINE fmap #-}
 
 instance Monad m => Apply (EitherT e m) where

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -171,14 +171,10 @@ instance Monad m => Apply (EitherT e m) where
       Right x -> return (Right (k x))
   {-# INLINE (<.>) #-}
 
-instance Monad m => Applicative (EitherT e m) where
-  pure a  = EitherT $ return (Right a)
+instance Applicative m => Applicative (EitherT e m) where
+  pure = EitherT . pure . Right
   {-# INLINE pure #-}
-  EitherT f <*> EitherT v = EitherT $ f >>= \mf -> case mf of
-    Left  e -> return (Left e)
-    Right k -> v >>= \mv -> case mv of
-      Left  e -> return (Left e)
-      Right x -> return (Right (k x))
+  (<*>) a b = EitherT $ (<*>) <$> runEitherT a <*> runEitherT b
   {-# INLINE (<*>) #-}
 
 instance (Monad m, Monoid e) => Alternative (EitherT e m) where

--- a/src/Control/Monad/Trans/Either.hs
+++ b/src/Control/Monad/Trans/Either.hs
@@ -163,12 +163,8 @@ instance Functor m => Functor (EitherT e m) where
   fmap f = EitherT . fmap (fmap f) . runEitherT
   {-# INLINE fmap #-}
 
-instance Monad m => Apply (EitherT e m) where
-  EitherT f <.> EitherT v = EitherT $ f >>= \mf -> case mf of
-    Left  e -> return (Left e)
-    Right k -> v >>= \mv -> case mv of
-      Left  e -> return (Left e)
-      Right x -> return (Right (k x))
+instance Apply m => Apply (EitherT e m) where
+  (<.>) a b = EitherT $ (<.>) <$> runEitherT a <.> runEitherT b
   {-# INLINE (<.>) #-}
 
 instance Applicative m => Applicative (EitherT e m) where
@@ -209,7 +205,7 @@ instance (Monad m, Semigroup e) => Alt (EitherT e m) where
     Right r -> return (Right r)
   {-# INLINE (<!>) #-}
 
-instance Monad m => Bind (EitherT e m) where
+instance (Monad m, Apply m) => Bind (EitherT e m) where
   (>>-) = (>>=)
   {-# INLINE (>>-) #-}
 


### PR DESCRIPTION
In my application I used the following stack:

```haskell
EitherT MyError Concurrently a
```

where `Concurrently` is a type from the "async" package, whose instances for `Applicative` and `Alternative` utilise concurrency. To my surprise I discovered that this stack behaved sequentially when used with Applicative operators. Then I found out that the cause was in the `EitherT` instances, which were implemented sequentially in terms of `Monad`.

This pull request fixes the instances and lightens the constraints.