### PR TITLE
Added a MFunctor instance for EitherT e

### DIFF
--- a/either.cabal
+++ b/either.cabal
@@ -34,6 +34,7 @@ library
     monad-control     >= 0.3.2   && < 1.1,
     MonadRandom       >= 0.1     && < 0.4,
     mtl               >= 2.0     && < 2.3,
+    mmorph            >= 1.0.0   && < 1.0.4,
     profunctors       >= 4       && < 6,
     semigroups        >= 0.8.3.1 && < 1,
     semigroupoids     >= 4       && < 6,


### PR DESCRIPTION
This is both a pull request and a question. Is there a reason why there is no `hoist` method for `EitherT`?