### PR TITLE
Add haddocks to `Alt` instance

### DIFF
--- a/src/Data/Either/Validation.hs
+++ b/src/Data/Either/Validation.hs
@@ -61,6 +61,7 @@ instance Semigroup e => Applicative (Validation e) where
   pure = Success
   (<*>) = (<.>)
 
+-- | For two errors, this instance reports both of them.
 instance Semigroup e => Alt (Validation e) where
   s@Success{} <!> _ = s
   _ <!> s@Success{} = s


### PR DESCRIPTION
This is mainly to make the difference to the `validation` package
clear, which has different behaviour.