### PR TITLE
Doc Fix - maybeToLeft function example

### DIFF
--- a/src/Data/Either/Combinators.hs
+++ b/src/Data/Either/Combinators.hs
@@ -313,7 +313,7 @@ rightToMaybe = either (const Nothing) Just
 
 -- | Maybe produce a 'Left', otherwise produce a 'Right'.
 --
--- >>> maybeTLeft "default" (Just 12)
+-- >>> maybeToLeft "default" (Just 12)
 -- Left 12
 --
 -- >>> maybeToLeft "default" Nothing

--- a/src/Data/Either/Combinators.hs
+++ b/src/Data/Either/Combinators.hs
@@ -313,10 +313,10 @@ rightToMaybe = either (const Nothing) Just
 
 -- | Maybe produce a 'Left', otherwise produce a 'Right'.
 --
--- >>> maybeToRight "default" (Just 12)
+-- >>> maybeTLeft "default" (Just 12)
 -- Left 12
 --
--- >>> maybeToRight "default" Nothing
+-- >>> maybeToLeft "default" Nothing
 -- Right "default"
 maybeToLeft :: b -> Maybe a -> Either a b
 maybeToLeft _ (Just x) = Left x


### PR DESCRIPTION
I noticed in the docs that this function example seems to reference `maybeToRight` when it seems like it should reference `maybeToLeft`.